### PR TITLE
Add split exit action

### DIFF
--- a/ui/app/templates/split/macro_list.jinja2
+++ b/ui/app/templates/split/macro_list.jinja2
@@ -50,7 +50,7 @@
 
         {% if not split.performed %}
             {% if is_joined %}
-            <div class="split-card-joined-badge">You're in</div>
+            <a href="{{ url_for('split.remove_participant', id=split.id, entity_id=g.actor_entity.id) }}" class="big-button big-button-outline big-button-danger-outline">Exit</a>
             {% else %}
             <a href="{{ url_for('split.add_participant', id=split.id) }}" class="big-button">Join</a>
             {% endif %}


### PR DESCRIPTION
Adds an Exit action for joined splits using the existing participant removal flow.

Before:
<img width="768" height="249" alt="image" src="https://github.com/user-attachments/assets/4f25d691-1402-487f-a710-72f2c9e33c51" />

After:
<img width="768" height="249" alt="image" src="https://github.com/user-attachments/assets/df0676f9-09be-47d6-97f5-60d0d1616271" />
