### PR TITLE
Fix Telegram login button background

### DIFF
--- a/ui/app/static/login.css
+++ b/ui/app/static/login.css
@@ -58,6 +58,10 @@
   position: relative;
 }
 
+iframe[id^="telegram-login-"] {
+  clip-path: inset(1px round 20px);
+}
+
 .form-label {
   display: block;
   font-weight: 600;


### PR DESCRIPTION
Removes black iframe corners around the Telegram login button in dark mode.

Before:
<img width="400" height="548" alt="image" src="https://github.com/user-attachments/assets/bc1a9408-064a-4855-b609-344760e4d849" />

After:
<img width="400" height="548" alt="image" src="https://github.com/user-attachments/assets/2877a4f3-ffb8-44d2-af64-15a0137f75b0" />
